### PR TITLE
fix(scripts): read confirmation from tty

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,8 +17,7 @@ EOF
 echo -e "\033[0m"
 
 # Ask user before continuing (especially important for Windows users)
-echo -n "Do you want to continue with the installation? (y/n): "
-read -r answer
+read -r -p "Do you want to continue? [y/N] " answer < /dev/tty
 if [[ ! "$answer" =~ ^[Yy]$ ]]; then
   echo "Installation cancelled by user."
   exit 0


### PR DESCRIPTION
Reading from stdin doesn't work when the install command is behind a pipe. In that case, stdin is not a tty but the output of the previous command, which in the case of the installation is curl with the script itself, and nothing more.

The script doesn't have anything to read in this case and immediately exits without doing anything.

Can be tested by using old and new versions with `cat install.sh | bash`.

Fixes #7 