### PR TITLE
fix: correct binary filename in install script for chmod/mv operations

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -74,7 +74,6 @@ curl -L -o froggit.zip "$URL"
 loading "📦 Unzipping"
 unzip -o froggit.zip
 
-# The extracted binary has the OS-ARCH suffix
 EXTRACTED_NAME="${BIN_NAME}-${OS}-${ARCH}"
 FINAL_NAME="${BIN_NAME}"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -74,11 +74,13 @@ curl -L -o froggit.zip "$URL"
 loading "📦 Unzipping"
 unzip -o froggit.zip
 
+# The extracted binary has the OS-ARCH suffix
+EXTRACTED_NAME="${BIN_NAME}-${OS}-${ARCH}"
 FINAL_NAME="${BIN_NAME}"
 
 loading "🚚 Installing to /usr/local/bin"
-chmod +x "$FINAL_NAME"
-sudo mv "$FINAL_NAME" /usr/local/bin/froggit
+chmod +x "$EXTRACTED_NAME"
+sudo mv "$EXTRACTED_NAME" /usr/local/bin/froggit
 
 echo -e "\n✅ \033[1;32mFroggit installed successfully!\033[0m"
 echo "👉 Run 'froggit' to get started 🐸"


### PR DESCRIPTION
### Description

Issue with "chmod: froggit: No such file or directory"  due acessing file anme "froggit" when the extracted binary is named with OS-ARCH suffix (e.g., "froggit-darwin-arm64").

Resolves the "No such file or directory" error during installation.